### PR TITLE
Optimized Dockerfile (distroless)

### DIFF
--- a/manifests/25-file-service-deployment-dev.yaml
+++ b/manifests/25-file-service-deployment-dev.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: alkemio-file-service
     spec:
+      securityContext:
+        fsGroup: 65532
+        runAsNonRoot: true
       containers:
         - name: alkemio-file-service
           image: rg.nl-ams.scw.cloud/alkemio/alkemio-file-service:latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-service",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-service",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-service",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-service",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-service",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A file serving microservice for the Alkemio platform",
   "main": "main.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-service",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A file serving microservice for the Alkemio platform",
   "main": "main.ts",
   "scripts": {


### PR DESCRIPTION
## Changes
- Implemented a multi-stage build to separate the build environment from the runtime environment.
- Switched the base image from node:alpine to distroless (gcr.io/distroless/nodejs22-debian12) for the production stage.
- Added npm prune --production to ensure only production dependencies are included in the final image.
- Removed source code and build configuration files from the final image, copying only the compiled dist folder and necessary config.
- Enforced running the container as a non-root user (USER nonroot) and set correct file ownership.
Results
- The image size has been significantly reduced by removing development dependencies, build tools, and source code.

## Results
Image|Size
---|---
Before|588 MB
After|266 MB


## Security improvements
- Reduced Attack Surface: The distroless image does not contain a shell, package managers, or other standard system utilities, making it much harder for attackers to exploit the container if they gain access.
- Non-Root Execution: Running as nonroot prevents the application from having root privileges within the container, mitigating the impact of potential container escape vulnerabilities.
- Minimal Dependencies: By excluding development dependencies and source code, we reduce the number of components that could potentially have vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined container build and runtime for smaller, leaner production images and simpler artifact handling.
  * Default NODE_ENV set to production and runtime execution simplified for consistent deployments.
* **Security**
  * Runtime now runs as a non-root user and enforces a non-root group for mounted volumes.
  * Production image updated to a minimal distroless base and exposes port 4003.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->