### PR TITLE
Fix type error from the logs

### DIFF
--- a/src/services/file-reader/file.adapter.service.ts
+++ b/src/services/file-reader/file.adapter.service.ts
@@ -50,9 +50,10 @@ export class FileAdapterService {
           'Client proxy successfully connected to RabbitMQ',
         );
       })
-      .catch(({ err }: RMQConnectionError) =>
-        this.logger.error(err, err.stack),
-      );
+      .catch((error: unknown) => {
+        const err = (error as RMQConnectionError)?.err || (error as Error);
+        this.logger.error(err?.message || String(error), err?.stack);
+      });
 
     this.timeoutMs = this.configService.get(
       'settings.application.response_timeout',
@@ -123,10 +124,11 @@ export class FileAdapterService {
       timeout({ each: timeoutMs }),
     );
 
-    return firstValueFrom(result$).catch(({ err }: RMQConnectionError) => {
+    return firstValueFrom(result$).catch((error: unknown) => {
+      const err = (error as RMQConnectionError)?.err || (error as Error);
       this.logger.error(
-        err.message,
-        err.stack,
+        err?.message || String(error),
+        err?.stack,
         JSON.stringify({
           pattern,
           data,


### PR DESCRIPTION
Saw some error in Kibana. This should fix the type error one:

<img width="1869" height="579" alt="Screenshot 2026-02-11 at 13 14 29" src="https://github.com/user-attachments/assets/cc13d4a0-6501-4a11-9185-3e85e465a4a9" />


```
{
  "@timestamp": [
    "2026-02-10T16:04:37.244Z"
  ],
  "@version": [
    "1"
  ],
  "@version.keyword": [
    "1"
  ],
  "agent.ephemeral_id": [
    "644da717-9771-4306-b861-d2934609fdbf"
  ],
  "agent.ephemeral_id.keyword": [
    "644da717-9771-4306-b861-d2934609fdbf"
  ],
  "agent.id": [
    "3636d902-4e63-4c76-a00b-c45eb2e5dbe5"
  ],
  "agent.id.keyword": [
    "3636d902-4e63-4c76-a00b-c45eb2e5dbe5"
  ],
  "agent.name": [
    "filebeat-beat-filebeat-hg5g4"
  ],
  "agent.name.keyword": [
    "filebeat-beat-filebeat-hg5g4"
  ],
  "agent.type": [
    "filebeat"
  ],
  "agent.type.keyword": [
    "filebeat"
  ],
  "agent.version": [
    "8.8.0"
  ],
  "agent.version.keyword": [
    "8.8.0"
  ],
  "container.id": [
    "7c3cbaddc522e211392f8cbc3f30229f6891f332294aa5db5eebe6ab0efc4b1b"
  ],
  "container.id.keyword": [
    "7c3cbaddc522e211392f8cbc3f30229f6891f332294aa5db5eebe6ab0efc4b1b"
  ],
  "container.image.name": [
    "alkemio/file-service:v0.2.0"
  ],
  "container.image.name.keyword": [
    "alkemio/file-service:v0.2.0"
  ],
  "container.runtime": [
    "containerd"
  ],
  "container.runtime.keyword": [
    "containerd"
  ],
  "ecs.version": [
    "8.0.0"
  ],
  "ecs.version.keyword": [
    "8.0.0"
  ],
  "event.original": [
    "{\"error\":{},\"label\":\"alkemio-file-service\",\"level\":\"error\",\"message\":\"Cannot read properties of undefined (reading 'message')\",\"stack\":[\"TypeError: Cannot read properties of undefined (reading 'message')\\n    at /usr/src/app/dist/services/file-reader/file.adapter.service.js:42:39\\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\\n    at async FileService.readDocument (/usr/src/app/dist/services/file-reader/file.service.js:46:26)\\n    at async FileController.file (/usr/src/app/dist/services/file-reader/file.controller.js:32:28)\\n    at async /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:46:28\\n    at async Object.<anonymous> (/usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17)\"],\"timestamp\":\"2026-02-10T16:04:37.243Z\"}"
  ],
  "event.original.keyword": [
    "{\"error\":{},\"label\":\"alkemio-file-service\",\"level\":\"error\",\"message\":\"Cannot read properties of undefined (reading 'message')\",\"stack\":[\"TypeError: Cannot read properties of undefined (reading 'message')\\n    at /usr/src/app/dist/services/file-reader/file.adapter.service.js:42:39\\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\\n    at async FileService.readDocument (/usr/src/app/dist/services/file-reader/file.service.js:46:26)\\n    at async FileController.file (/usr/src/app/dist/services/file-reader/file.controller.js:32:28)\\n    at async /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:46:28\\n    at async Object.<anonymous> (/usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17)\"],\"timestamp\":\"2026-02-10T16:04:37.243Z\"}"
  ],
  "host.name": [
    "filebeat-beat-filebeat-hg5g4"
  ],
  "host.name.keyword": [
    "filebeat-beat-filebeat-hg5g4"
  ],
  "input.type": [
    "container"
  ],
  "input.type.keyword": [
    "container"
  ],
  "kubernetes.container.name": [
    "alkemio-file-service"
  ],
  "kubernetes.container.name.keyword": [
    "alkemio-file-service"
  ],
  "kubernetes.labels.app": [
    "alkemio-file-service"
  ],
  "kubernetes.labels.app.keyword": [
    "alkemio-file-service"
  ],
  "kubernetes.labels.pod-template-hash": [
    "7dbcdf5bfc"
  ],
  "kubernetes.labels.pod-template-hash.keyword": [
    "7dbcdf5bfc"
  ],
  "kubernetes.namespace": [
    "default"
  ],
  "kubernetes.namespace.keyword": [
    "default"
  ],
  "kubernetes.namespace_labels.kubernetes_io/metadata_name": [
    "default"
  ],
  "kubernetes.namespace_labels.kubernetes_io/metadata_name.keyword": [
    "default"
  ],
  "kubernetes.namespace_uid": [
    "4a761324-e94d-4fb6-9902-d9278cb64b04"
  ],
  "kubernetes.namespace_uid.keyword": [
    "4a761324-e94d-4fb6-9902-d9278cb64b04"
  ],
  "kubernetes.node.hostname": [
    "scw-prod-new-cluste-prod-new-compute-po-835f59"
  ],
  "kubernetes.node.hostname.keyword": [
    "scw-prod-new-cluste-prod-new-compute-po-835f59"
  ],
  "kubernetes.node.labels.beta_kubernetes_io/arch": [
    "amd64"
  ],
  "kubernetes.node.labels.beta_kubernetes_io/arch.keyword": [
    "amd64"
  ],
  "kubernetes.node.labels.beta_kubernetes_io/instance-type": [
    "POP2-HC-8C-16G"
  ],
  "kubernetes.node.labels.beta_kubernetes_io/instance-type.keyword": [
    "POP2-HC-8C-16G"
  ],
  "kubernetes.node.labels.beta_kubernetes_io/os": [
    "linux"
  ],
  "kubernetes.node.labels.beta_kubernetes_io/os.keyword": [
    "linux"
  ],
  "kubernetes.node.labels.failure-domain_beta_kubernetes_io/region": [
    "nl-ams"
  ],
  "kubernetes.node.labels.failure-domain_beta_kubernetes_io/region.keyword": [
    "nl-ams"
  ],
  "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone": [
    "nl-ams-1"
  ],
  "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone.keyword": [
    "nl-ams-1"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/environment": [
    "production"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/environment.keyword": [
    "production"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/kapsule": [
    "bbbaebcf-c4bb-45e8-aa3e-fbc3ef625153"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/kapsule.keyword": [
    "bbbaebcf-c4bb-45e8-aa3e-fbc3ef625153"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/managed": [
    "true"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/managed.keyword": [
    "true"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/node": [
    "835f59f4-9615-47ba-9b53-b3f7b003e28e"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/node.keyword": [
    "835f59f4-9615-47ba-9b53-b3f7b003e28e"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/pool": [
    "29b3f9d7-2ea8-4bff-af0a-4751825cc720"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/pool-name": [
    "prod-new-compute-pool"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/pool-name.keyword": [
    "prod-new-compute-pool"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/pool.keyword": [
    "29b3f9d7-2ea8-4bff-af0a-4751825cc720"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/project": [
    "alkemio"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/project.keyword": [
    "alkemio"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/runtime": [
    "containerd"
  ],
  "kubernetes.node.labels.k8s_scaleway_com/runtime.keyword": [
    "containerd"
  ],
  "kubernetes.node.labels.kubernetes_io/arch": [
    "amd64"
  ],
  "kubernetes.node.labels.kubernetes_io/arch.keyword": [
    "amd64"
  ],
  "kubernetes.node.labels.kubernetes_io/hostname": [
    "scw-prod-new-cluste-prod-new-compute-po-835f59"
  ],
  "kubernetes.node.labels.kubernetes_io/hostname.keyword": [
    "scw-prod-new-cluste-prod-new-compute-po-835f59"
  ],
  "kubernetes.node.labels.kubernetes_io/os": [
    "linux"
  ],
  "kubernetes.node.labels.kubernetes_io/os.keyword": [
    "linux"
  ],
  "kubernetes.node.labels.node_kubernetes_io/instance-type": [
    "POP2-HC-8C-16G"
  ],
  "kubernetes.node.labels.node_kubernetes_io/instance-type.keyword": [
    "POP2-HC-8C-16G"
  ],
  "kubernetes.node.labels.topology_csi_scaleway_com/zone": [
    "nl-ams-1"
  ],
  "kubernetes.node.labels.topology_csi_scaleway_com/zone.keyword": [
    "nl-ams-1"
  ],
  "kubernetes.node.labels.topology_kubernetes_io/region": [
    "nl-ams"
  ],
  "kubernetes.node.labels.topology_kubernetes_io/region.keyword": [
    "nl-ams"
  ],
  "kubernetes.node.labels.topology_kubernetes_io/zone": [
    "nl-ams-1"
  ],
  "kubernetes.node.labels.topology_kubernetes_io/zone.keyword": [
    "nl-ams-1"
  ],
  "kubernetes.node.name": [
    "scw-prod-new-cluste-prod-new-compute-po-835f59"
  ],
  "kubernetes.node.name.keyword": [
    "scw-prod-new-cluste-prod-new-compute-po-835f59"
  ],
  "kubernetes.node.uid": [
    "e306f5c0-db9d-43ac-bd0b-141f82d5204b"
  ],
  "kubernetes.node.uid.keyword": [
    "e306f5c0-db9d-43ac-bd0b-141f82d5204b"
  ],
  "kubernetes.pod.ip": [
    "100.64.5.71"
  ],
  "kubernetes.pod.ip.keyword": [
    "100.64.5.71"
  ],
  "kubernetes.pod.name": [
    "alkemio-file-service-deployment-7dbcdf5bfc-jgck5"
  ],
  "kubernetes.pod.name.keyword": [
    "alkemio-file-service-deployment-7dbcdf5bfc-jgck5"
  ],
  "kubernetes.pod.uid": [
    "c3cda97c-3890-4bfa-8614-27af06164346"
  ],
  "kubernetes.pod.uid.keyword": [
    "c3cda97c-3890-4bfa-8614-27af06164346"
  ],
  "kubernetes.replicaset.name": [
    "alkemio-file-service-deployment-7dbcdf5bfc"
  ],
  "kubernetes.replicaset.name.keyword": [
    "alkemio-file-service-deployment-7dbcdf5bfc"
  ],
  "label": [
    "alkemio-file-service"
  ],
  "label.keyword": [
    "alkemio-file-service"
  ],
  "level": [
    "error"
  ],
  "level.keyword": [
    "error"
  ],
  "log.file.path": [
    "/var/log/containers/alkemio-file-service-deployment-7dbcdf5bfc-jgck5_default_alkemio-file-service-7c3cbaddc522e211392f8cbc3f30229f6891f332294aa5db5eebe6ab0efc4b1b.log"
  ],
  "log.file.path.keyword": [
    "/var/log/containers/alkemio-file-service-deployment-7dbcdf5bfc-jgck5_default_alkemio-file-service-7c3cbaddc522e211392f8cbc3f30229f6891f332294aa5db5eebe6ab0efc4b1b.log"
  ],
  "log.offset": [
    2564481
  ],
  "message": [
    "Cannot read properties of undefined (reading 'message')"
  ],
  "message.keyword": [
    "Cannot read properties of undefined (reading 'message')"
  ],
  "stack": [
    "TypeError: Cannot read properties of undefined (reading 'message')\n    at /usr/src/app/dist/services/file-reader/file.adapter.service.js:42:39\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async FileService.readDocument (/usr/src/app/dist/services/file-reader/file.service.js:46:26)\n    at async FileController.file (/usr/src/app/dist/services/file-reader/file.controller.js:32:28)\n    at async /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:46:28\n    at async Object.<anonymous> (/usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17)"
  ],
  "stack.keyword": [
    "TypeError: Cannot read properties of undefined (reading 'message')\n    at /usr/src/app/dist/services/file-reader/file.adapter.service.js:42:39\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async FileService.readDocument (/usr/src/app/dist/services/file-reader/file.service.js:46:26)\n    at async FileController.file (/usr/src/app/dist/services/file-reader/file.controller.js:32:28)\n    at async /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:46:28\n    at async Object.<anonymous> (/usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17)"
  ],
  "stream": [
    "stdout"
  ],
  "stream.keyword": [
    "stdout"
  ],
  "tags": [
    "beats_input_codec_plain_applied"
  ],
  "tags.keyword": [
    "beats_input_codec_plain_applied"
  ],
  "timestamp": [
    "2026-02-10T16:04:37.243Z"
  ],
  "_id": "GUxMSJwBY5D1eh8HQyo_",
  "_ignored": [
    "event.original.keyword",
    "stack.keyword"
  ],
  "_index": ".ds-logstash-output-alkemio-file-service-2026.01.14-000049",
  "_score": null
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and logging for file operations to provide more reliable error messages and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->