### PR TITLE
chore(ci): add multiarch builds to Hetzner deploy workflows

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -11,19 +11,32 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.7
 
-      - name: 'Login into ACR'
-        uses: azure/docker-login@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Login to ACR
+        uses: docker/login-action@v3.7.0
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: 'Build & Push image'
-        run: |
-          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }}
+      - name: Build and push
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }}
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:latest
 
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -10,19 +10,32 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.7
 
-      - name: 'Login into ACR'
-        uses: azure/docker-login@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Login to ACR
+        uses: docker/login-action@v3.7.0
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: 'Build & Push image'
-        run: |
-          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }}
+      - name: Build and push
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }}
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:latest
 
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -10,19 +10,32 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.7
 
-      - name: 'Login into ACR'
-        uses: azure/docker-login@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Login to ACR
+        uses: docker/login-action@v3.7.0
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: 'Build & Push image'
-        run: |
-          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }}
+      - name: Build and push
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:${{ github.sha }}
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-file-service:latest
 
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'


### PR DESCRIPTION
## Summary
- Replace `azure/docker-login@v2` + raw `docker build`/`docker push` with `docker/login-action@v3.7.0` + `docker/setup-qemu-action@v3.7.0` + `docker/setup-buildx-action@v3.12.0` + `docker/build-push-action@v6.18.0` in all three Hetzner deploy workflows (dev, sandbox, test)
- Builds now produce multiarch images (`linux/amd64,linux/arm64`), matching the existing Docker Hub release workflow
- Adds `needs: build` to `deploy` jobs so they correctly wait for the build to finish

## Test plan
- [ ] Verify the three modified workflows match the pattern used in `build-release-docker-hub.yml`
- [ ] Trigger a dev deploy (push to develop) and confirm the multiarch image is built and pushed
- [ ] Trigger sandbox and test deploys (workflow_dispatch) and confirm they succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)